### PR TITLE
 Remove jquery from enque and deregister it

### DIFF
--- a/wp-content/themes/theme_name/inc/enqueue.php
+++ b/wp-content/themes/theme_name/inc/enqueue.php
@@ -9,36 +9,27 @@ add_action( 'wp_enqueue_scripts', 'inf_register_scripts', 1 );
 
 if ( ! function_exists( 'inf_register_scripts' ) ) {
 
-	/**
-	 * Register global theme scripts
-	 */
-	function inf_register_scripts() {
+  /**
+   * Register global theme scripts
+   */
+  function inf_register_scripts() {
 
-		// jQuery.
-		$jquery_cdn = 'https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js';
-		$jquery_cdn_response = wp_remote_get( $jquery_cdn )['response']['code'];
+    // Remove jQuery because it is bundled in with webpack.
+    wp_deregister_script( 'jquery' );
 
-		if ( 200 === $jquery_cdn_response ) {
-			wp_deregister_script( 'jquery' );
-			wp_register_script( 'jquery', $jquery_cdn, array(), '3.1.1' );
-			wp_enqueue_script( 'jquery' );
-		} else {
-			wp_enqueue_script( 'jquery' );
-		}
+    // JS.
+    wp_register_script( 'scripts', get_template_directory_uri() . '/skin/public/scripts/application.js', array( 'jquery' ), ASSETS_VERSION );
+    wp_enqueue_script( 'scripts' );
 
-		// JS.
-		wp_register_script( 'scripts', get_template_directory_uri() . '/skin/public/scripts/application.js', array( 'jquery' ), ASSETS_VERSION );
-		wp_enqueue_script( 'scripts' );
+    // CSS.
+    wp_register_style( 'style', get_template_directory_uri() . '/skin/public/styles/application.css', array(), ASSETS_VERSION );
+    wp_enqueue_style( 'style' );
 
-		// CSS.
-		wp_register_style( 'style', get_template_directory_uri() . '/skin/public/styles/application.css', array(), ASSETS_VERSION );
-		wp_enqueue_style( 'style' );
-
-		// Ajax.
-		wp_localize_script( 'scripts', 'themeLocalization', array(
-			'ajaxurl' => admin_url( 'admin-ajax.php' ),
-		) );
-	}
+    // Ajax.
+    wp_localize_script( 'scripts', 'themeLocalization', array(
+        'ajaxurl' => admin_url( 'admin-ajax.php' ),
+    ) );
+  }
 }
 
 /**


### PR DESCRIPTION
Webpack bundles jQuery, no need for WP to add it again.