### PR TITLE
Flex grid mixin

### DIFF
--- a/skin/assets/styles/utils/_mixins.scss
+++ b/skin/assets/styles/utils/_mixins.scss
@@ -4,3 +4,4 @@
 @import 'mixins/forms';
 @import 'mixins/buttons';
 @import 'mixins/sections';
+@import 'mixins/flex';

--- a/skin/assets/styles/utils/_shared-variables.scss
+++ b/skin/assets/styles/utils/_shared-variables.scss
@@ -7,6 +7,10 @@ $base-content-padding: 15px;
 $base-content-full-width: 1200px;
 $base-content-width: $base-content-full-width + ($base-content-padding*2);
 
+// Grid
+$base-gutter-size: $base-content-padding;
+$base-col-number: 12;
+
 //Typography
 $typography-map: (
   mobile: (

--- a/skin/assets/styles/utils/mixins/_flex.scss
+++ b/skin/assets/styles/utils/mixins/_flex.scss
@@ -1,0 +1,82 @@
+/*
+ * Mixin that creates flex grid.
+ * It should be applied to the container element that will act as grid row.
+ * All of the child elements will act as grid columns.
+ * Parameters to configure:
+ *
+ * * $layout - column width relative to th number of columns. If defined as a number all colums will be same width,
+ * and if set as a list width is set sequetially for each item.
+ * * $gutter - spacing between each item.
+ * * $col-count - max number of columns.
+ * * $horizontal - horizontal alignment of the items. Uses values for justify-content property.
+ * * $vertical - vertical alignment of th items. Uses valuse for align-items property.
+ * * $order - a list of item order overrides.
+ */
+@mixin flex-container(
+  $layout: (),
+  $gutter: $base-gutter-size,
+  $col-count: $base-col-number,
+  $horizontal: flex-start,
+  $vertical: stretch,
+  $order: 0
+) {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: $horizontal;
+  align-items: $vertical;
+  margin: 0 -#{$gutter};
+
+  & > * {
+    padding: 0 #{$gutter};
+  }
+
+  // Logic for defining layout of the columns.
+  @if length($layout) > 0 {
+    @if type-of($layout) == list {
+      // Looping over each item in $layout list and grabbing their index.
+      @for $index from 1 through length($layout) {
+        // Value of current item from the list.
+        $item: nth($layout, $index);
+
+        // Child element selector for current index.
+        & > :nth-child( #{$index} ) {
+          // Setting the width of the column as a relation between max column number and width of the column.
+          flex: 0 0 #{100% / ( $col-count / $item )};
+          max-width: #{100% /  ( $col-count / $item )};
+        }
+      }
+    }
+    // Setting the width of all columns as a relation between max column number and width of the columns.
+    @if type-of($layout) == number {
+      & > * {
+        flex: 0 0 #{100% / ( $col-count / $layout )};
+        max-width: #{100% /  ( $col-count / $layout )};
+      }
+    }
+  }
+  // Fallback for undefined layout
+  @else {
+    & > * {
+      flex: 1 0 0;
+      max-width: 100%;
+    }
+  }
+  // Logic for defining order of the columns.
+  @if length($order) > 0 {
+    @if type-of($order) == list {
+      @for $index from 1 through length($order) {
+        $item: nth($order, $index);
+
+        & > :nth-child( #{$index} ) {
+          order: $item;
+        }
+      }
+    }
+    @if type-of($order) == number {
+      & > * {
+        order: $order;
+      }
+    }
+  }
+
+}

--- a/skin/assets/styles/utils/mixins/_flex.scss
+++ b/skin/assets/styles/utils/mixins/_flex.scss
@@ -5,7 +5,7 @@
  * Parameters to configure:
  *
  * * $layout - column width relative to th number of columns. If defined as a number all colums will be same width,
- * and if set as a list width is set sequetially for each item.
+ * and if set as a list width is set sequentially for each item.
  * * $gutter - spacing between each item.
  * * $col-count - max number of columns.
  * * $horizontal - horizontal alignment of the items. Uses values for justify-content property.


### PR DESCRIPTION
Mixin for creating flex grid.
It is defined on container element and applies to all of its child elements.
Base gutter size is 15px, max column count is 12 and can be overridden.
Layout can be set as a number or a list. When set as a number all columns have the same width. When set as a list width of columns is set sequentially. Width of the columns is defined as a relation between max column size and layout value.
Columns can be aligned horizontally, vertically and can be reordered with order list.
It can be combined with media queries and included on every breakpoint with different parameters.
