### PR TITLE
3.0.1 release update fixes

### DIFF
--- a/admin/class-media.php
+++ b/admin/class-media.php
@@ -92,10 +92,10 @@ class Media {
 
           // media single.
           $response['sizes']['full'] = array(
-              'height'      => $height,
-              'width'       => $width,
-              'url'         => $src,
-              'orientation' => $height > $width ? 'portrait' : 'landscape',
+            'height'      => $height,
+            'width'       => $width,
+            'url'         => $src,
+            'orientation' => $height > $width ? 'portrait' : 'landscape',
           );
         }
       } catch ( \Exception $e ) {
@@ -127,8 +127,8 @@ class Media {
       if ( file_exists( $path ) ) {
         if ( ! $this->is_valid_xml( $svg_content ) ) {
           return array(
-              'size' => $response,
-              'name' => $response['name'],
+            'size' => $response,
+            'name' => $response['name'],
           );
         }
       }

--- a/admin/class-widget.php
+++ b/admin/class-widget.php
@@ -22,13 +22,13 @@ class Widget {
   public function register_widget_position() {
     register_sidebar(
       array(
-          'name'          => esc_html__( 'Blog', 'inf_theme' ),
-          'id'            => 'blog',
-          'description'   => esc_html__( 'Description', 'inf_theme' ),
-          'before_widget' => '',
-          'after_widget'  => '',
-          'before_title'  => '',
-          'after_title'   => '',
+        'name'          => esc_html__( 'Blog', 'inf_theme' ),
+        'id'            => 'blog',
+        'description'   => esc_html__( 'Description', 'inf_theme' ),
+        'before_widget' => '',
+        'after_widget'  => '',
+        'before_title'  => '',
+        'after_title'   => '',
       )
     );
   }

--- a/admin/menu/class-bem-menu-walker.php
+++ b/admin/menu/class-bem-menu-walker.php
@@ -71,11 +71,12 @@ class Bem_Menu_Walker extends \Walker_Nav_Menu {
    *
    * @param array   $output output.
    * @param integer $depth depth.
+   * @param array   $args args.
    * @return void
    *
    * @since 1.0.0
    */
-  public function start_lvl( &$output, $depth = 1 ) {
+  public function start_lvl( &$output, $depth = 1, $args = array() ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassAfterLastUsed
 
     $real_depth = $depth + 1;
 
@@ -102,11 +103,12 @@ class Bem_Menu_Walker extends \Walker_Nav_Menu {
    * @param array   $item item.
    * @param integer $depth depth.
    * @param array   $args args.
+   * @param integer $id id.
    * @return void
    *
    * @since 1.0.0
    */
-  public function start_el( &$output, $item, $depth = 0, $args = array() ) {
+  public function start_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {  // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassAfterLastUsed
 
     global $wp_query;
 

--- a/admin/menu/class-bem-menu-walker.php
+++ b/admin/menu/class-bem-menu-walker.php
@@ -30,14 +30,14 @@ class Bem_Menu_Walker extends \Walker_Nav_Menu {
 
     // Define menu item names appropriately.
     $this->item_css_class_suffixes = array(
-        'item'                    => '__item',
-        'parent_item'             => '__item--parent',
-        'active_item'             => '__item--active',
-        'parent_of_active_item'   => '__item--parent--active',
-        'ancestor_of_active_item' => '__item--ancestor--active',
-        'sub_menu'                => '__sub-menu',
-        'sub_menu_item'           => '__sub-menu__item',
-        'link'                    => '__link',
+      'item'                    => '__item',
+      'parent_item'             => '__item--parent',
+      'active_item'             => '__item--active',
+      'parent_of_active_item'   => '__item--parent--active',
+      'ancestor_of_active_item' => '__item--ancestor--active',
+      'sub_menu'                => '__sub-menu',
+      'sub_menu_item'           => '__sub-menu__item',
+      'link'                    => '__link',
     );
   }
 
@@ -71,12 +71,11 @@ class Bem_Menu_Walker extends \Walker_Nav_Menu {
    *
    * @param array   $output output.
    * @param integer $depth depth.
-   * @param array   $args args.
    * @return void
    *
    * @since 1.0.0
    */
-  public function start_lvl( &$output, $depth = 1, $args = array() ) {
+  public function start_lvl( &$output, $depth = 1 ) {
 
     $real_depth = $depth + 1;
 
@@ -86,8 +85,8 @@ class Bem_Menu_Walker extends \Walker_Nav_Menu {
     $suffix = $this->item_css_class_suffixes;
 
     $classes = array(
-        $prefix . $suffix['sub_menu'],
-        $prefix . $suffix['sub_menu'] . '--' . $real_depth,
+      $prefix . $suffix['sub_menu'],
+      $prefix . $suffix['sub_menu'] . '--' . $real_depth,
     );
 
     $class_names = implode( ' ', $classes );
@@ -103,12 +102,11 @@ class Bem_Menu_Walker extends \Walker_Nav_Menu {
    * @param array   $item item.
    * @param integer $depth depth.
    * @param array   $args args.
-   * @param integer $id id.
    * @return void
    *
    * @since 1.0.0
    */
-  public function start_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
+  public function start_el( &$output, $item, $depth = 0, $args = array() ) {
 
     global $wp_query;
 
@@ -132,14 +130,14 @@ class Bem_Menu_Walker extends \Walker_Nav_Menu {
 
     // Item classes.
     $item_classes = array(
-        'item_class'            => 0 === $depth ? $prefix . $suffix['item'] : '',
-        'parent_class'          => $args->has_children ? $parent_class : '',
-        'active_page_class'     => in_array( 'current-menu-item', $item->classes, true ) ? $prefix . $suffix['active_item'] : '',
-        'active_parent_class'   => in_array( 'current-menu-parent', $item->classes, true ) ? $prefix . $suffix['parent_of_active_item'] : '',
-        'active_ancestor_class' => in_array( 'current-page-ancestor', $item->classes, true ) ? $prefix . $suffix['ancestor_of_active_item'] : '',
-        'depth_class'           => $depth >= 1 ? $prefix . $suffix['sub_menu_item'] . ' ' . $prefix . $suffix['sub_menu'] . '--' . $depth . '__item' : '',
-        'item_id_class'         => $prefix . '__item--' . $item->object_id,
-        'user_class'            => ! empty( $user_classes ) ? implode( ' ', $user_classes ) : '',
+      'item_class'            => 0 === $depth ? $prefix . $suffix['item'] : '',
+      'parent_class'          => $args->has_children ? $parent_class : '',
+      'active_page_class'     => in_array( 'current-menu-item', $item->classes, true ) ? $prefix . $suffix['active_item'] : '',
+      'active_parent_class'   => in_array( 'current-menu-parent', $item->classes, true ) ? $prefix . $suffix['parent_of_active_item'] : '',
+      'active_ancestor_class' => in_array( 'current-page-ancestor', $item->classes, true ) ? $prefix . $suffix['ancestor_of_active_item'] : '',
+      'depth_class'           => $depth >= 1 ? $prefix . $suffix['sub_menu_item'] . ' ' . $prefix . $suffix['sub_menu'] . '--' . $depth . '__item' : '',
+      'item_id_class'         => $prefix . '__item--' . $item->object_id,
+      'user_class'            => ! empty( $user_classes ) ? implode( ' ', $user_classes ) : '',
     );
 
     // Convert array to string excluding any empty values.
@@ -150,8 +148,8 @@ class Bem_Menu_Walker extends \Walker_Nav_Menu {
 
     // Link classes.
     $link_classes = array(
-        'item_link'   => 0 === $depth ? $prefix . $suffix['link'] : '',
-        'depth_class' => $depth >= 1 ? $prefix . $suffix['sub_menu'] . $suffix['link'] . '  ' . $prefix . $suffix['sub_menu'] . '--' . $depth . $suffix['link'] : '',
+      'item_link'   => 0 === $depth ? $prefix . $suffix['link'] : '',
+      'depth_class' => $depth >= 1 ? $prefix . $suffix['sub_menu'] . $suffix['link'] . '  ' . $prefix . $suffix['sub_menu'] . '--' . $depth . $suffix['link'] : '',
     );
 
     $link_class_string = implode( '  ', array_filter( $link_classes ) );
@@ -159,8 +157,8 @@ class Bem_Menu_Walker extends \Walker_Nav_Menu {
     $link_class_output = 'class="' . $link_class_string . ' "';
 
     $link_text_classes = array(
-        'item_link'   => 0 === $depth ? $prefix . $suffix['link'] . '-text' : '',
-        'depth_class' => $depth >= 1 ? $prefix . $suffix['sub_menu'] . $suffix['link'] . '-text ' . $prefix . $suffix['sub_menu'] . '--' . $depth . $suffix['link'] . '-text' : '',
+      'item_link'   => 0 === $depth ? $prefix . $suffix['link'] . '-text' : '',
+      'depth_class' => $depth >= 1 ? $prefix . $suffix['sub_menu'] . $suffix['link'] . '-text ' . $prefix . $suffix['sub_menu'] . '--' . $depth . $suffix['link'] . '-text' : '',
     );
 
     $link_text_class_string = implode( '  ', array_filter( $link_text_classes ) );

--- a/admin/menu/class-menu.php
+++ b/admin/menu/class-menu.php
@@ -22,8 +22,8 @@ class Menu {
    */
   public function get_menu_positions() {
     return array(
-        'header_main_nav' => esc_html__( 'Main Menu', 'inf_theme' ),
-        'footer_main_nav' => esc_html__( 'Footer Menu', 'inf_theme' ),
+      'header_main_nav' => esc_html__( 'Main Menu', 'inf_theme' ),
+      'footer_main_nav' => esc_html__( 'Footer Menu', 'inf_theme' ),
     );
   }
 
@@ -64,15 +64,15 @@ class Menu {
     }
 
       $args = array(
-          'theme_location' => $location,
-          'container'      => false,
-          'items_wrap'     => '<ul class="' . $css_class_prefix . ' ' . $modifiers . '">%3$s</ul>',
-          'echo'           => $echo,
-          'walker'         => new Bem_Menu_Walker( $css_class_prefix ),
+        'theme_location' => $location,
+        'container'      => false,
+        'items_wrap'     => '<ul class="' . $css_class_prefix . ' ' . $modifiers . '">%3$s</ul>',
+        'echo'           => $echo,
+        'walker'         => new Bem_Menu_Walker( $css_class_prefix ),
       );
 
-    if ( has_nav_menu( $location ) ) {
-      return wp_nav_menu( $args );
-    }
+      if ( has_nav_menu( $location ) ) {
+        return wp_nav_menu( $args );
+      }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,32 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73b987ccb74fe6f7a9a7f6d7ef2f2192",
+    "content-hash": "2ef6d71c3b61e718bfb9da1038acf9ee",
     "packages": [],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.4.4",
+            "version": "v0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08"
+                "reference": "e749410375ff6fb7a040a68878c656c2e610b132"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/2e41850d5f7797cbb1af7b030d245b3b24e63a08",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e749410375ff6fb7a040a68878c656c2e610b132",
+                "reference": "e749410375ff6fb7a040a68878c656c2e610b132",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0",
                 "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "*"
+                "squizlabs/php_codesniffer": "^2|^3"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "wimg/php-compatibility": "^8.0"
-            },
-            "suggest": {
-                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -49,13 +47,13 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "f.nijhof@dealerdirect.nl",
-                    "homepage": "http://workingatdealerdirect.eu",
-                    "role": "Developer"
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://workingatdealerdirect.eu",
+            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -73,25 +71,36 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2017-12-06T16:27:17+00:00"
+            "time": "2018-10-26T13:21:45+00:00"
         },
         {
             "name": "infinum/coding-standards-wp",
-            "version": "0.3.1",
+            "version": "0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/infinum/coding-standards-wp.git",
-                "reference": "03ce9f035f930d225d3ffeb0f79b26ba52a0b6ef"
+                "reference": "87aa3608eb064308291f8f7f3d3d30a8fd1ea296"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/infinum/coding-standards-wp/zipball/03ce9f035f930d225d3ffeb0f79b26ba52a0b6ef",
-                "reference": "03ce9f035f930d225d3ffeb0f79b26ba52a0b6ef",
+                "url": "https://api.github.com/repos/infinum/coding-standards-wp/zipball/87aa3608eb064308291f8f7f3d3d30a8fd1ea296",
+                "reference": "87aa3608eb064308291f8f7f3d3d30a8fd1ea296",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "*",
-                "wp-coding-standards/wpcs": ">=1.0.0"
+                "php": ">=5.6",
+                "phpcompatibility/phpcompatibility-wp": "^2.0",
+                "squizlabs/php_codesniffer": "^3.3.0",
+                "wp-coding-standards/wpcs": "^1.0.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "roave/security-advisories": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -113,20 +122,178 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-07-27T15:42:30+00:00"
+            "time": "2018-11-15T12:49:58+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.3.2",
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
-                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
+                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                },
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-12-30T23:16:27+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "9160de79fcd683b5c99e9c4133728d91529753ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/9160de79fcd683b5c99e9c4133728d91529753ea",
+                "reference": "9160de79fcd683b5c99e9c4133728d91529753ea",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards"
+            ],
+            "time": "2018-12-16T19:10:44+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
+                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2018-10-07T18:31:37+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "5b4333b4010625d29580eb4a41f1e53251be6baa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5b4333b4010625d29580eb4a41f1e53251be6baa",
+                "reference": "5b4333b4010625d29580eb4a41f1e53251be6baa",
                 "shasum": ""
             },
             "require": {
@@ -159,25 +326,25 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-09-23T23:08:17+00:00"
+            "time": "2019-03-19T03:22:27+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "1.1.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "46d42828ce7355d8b3776e3171f2bda892d179b4"
+                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/46d42828ce7355d8b3776e3171f2bda892d179b4",
-                "reference": "46d42828ce7355d8b3776e3171f2bda892d179b4",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
+                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
                 "shasum": ""
             },
             "require": {
@@ -185,7 +352,7 @@
                 "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
             },
             "require-dev": {
-                "phpcompatibility/php-compatibility": "*"
+                "phpcompatibility/php-compatibility": "^9.0"
             },
             "suggest": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
@@ -207,7 +374,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-09-10T17:04:05+00:00"
+            "time": "2018-12-18T09:43:51+00:00"
         }
     ],
     "aliases": [],

--- a/includes/class-loader.php
+++ b/includes/class-loader.php
@@ -113,11 +113,11 @@ class Loader {
    */
   private function add( $hooks, $hook, $component, $callback, $priority, $accepted_args ) {
     $hooks[] = array(
-        'hook'          => $hook,
-        'component'     => $component,
-        'callback'      => $callback,
-        'priority'      => $priority,
-        'accepted_args' => $accepted_args,
+      'hook'          => $hook,
+      'component'     => $component,
+      'callback'      => $callback,
+      'priority'      => $priority,
+      'accepted_args' => $accepted_args,
     );
 
     return $hooks;

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "autoprefixer": "^9.1.3",
     "css-mqpacker": "^7.0.0",
     "cssnano": "^4.1.0",
-    "jquery": "^3.3.1",
     "layzr.js": "^2.2.2",
     "media-blender": "^2.1.0",
     "normalize-scss": "^7.0.1",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,9 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="Infinum">
+<ruleset name="InfinumBoilerplate">
   <description>Loader for the Infinum coding standards for WordPress.</description>
 
-  <config name="installed_paths" value="vendor/wp-coding-standards/wpcs" />
-  <rule ref="vendor/infinum/coding-standards-wp/Infinum/ruleset.xml" />
+  <rule ref="Infinum" />
 
   <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.Found">
     <severity>0</severity>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="InfinumBoilerplate">
+<ruleset name="WPBoilerplate">
   <description>Loader for the Infinum coding standards for WordPress.</description>
 
   <rule ref="Infinum" />

--- a/search.php
+++ b/search.php
@@ -32,7 +32,7 @@ if ( have_posts() ) {
 
   the_posts_pagination(
     array(
-        'screen_reader_text' => ' ',
+      'screen_reader_text' => ' ',
     )
   );
 

--- a/theme/class-theme.php
+++ b/theme/class-theme.php
@@ -42,7 +42,7 @@ class Theme extends Config {
   public function enqueue_scripts() {
 
     // JS.
-    wp_register_script( static::THEME_NAME . '-scripts-vendors', General_Helper::get_manifest_assets_data( 'vendors.js' ), array(), static::THEME_VERSION, true );
+    wp_register_script( static::THEME_NAME . '-scripts-vendors', General_Helper::get_manifest_assets_data( 'vendors.js' ), array( 'jquery' ), static::THEME_VERSION, true );
     wp_enqueue_script( static::THEME_NAME . '-scripts-vendors' );
 
     wp_register_script( static::THEME_NAME . '-scripts', General_Helper::get_manifest_assets_data( 'application.js' ), array( static::THEME_NAME . '-scripts-vendors' ), static::THEME_VERSION, true );
@@ -53,7 +53,7 @@ class Theme extends Config {
       static::THEME_NAME . '-scripts',
       'themeLocalization',
       array(
-          'ajaxurl' => admin_url( 'admin-ajax.php' ),
+        'ajaxurl' => admin_url( 'admin-ajax.php' ),
       )
     );
   }

--- a/theme/utils/class-images.php
+++ b/theme/utils/class-images.php
@@ -39,16 +39,16 @@ class Images {
       $image         = wp_get_attachment_image_src( $attachemnt_id, $size );
 
       $image_array = [
-          'image'  => $image[0],
-          'width'  => $image[1],
-          'height' => $image[2],
+        'image'  => $image[0],
+        'width'  => $image[1],
+        'height' => $image[2],
       ];
     } else {
       $no_img      = General_Helper::get_manifest_assets_data( 'images/no-image-' . $size . '.jpg' );
       $image_array = [
-          'image'  => $no_img,
-          'width'  => '',
-          'height' => '',
+        'image'  => $no_img,
+        'width'  => '',
+        'height' => '',
       ];
 
       if ( ! empty( $no_image ) ) {
@@ -77,7 +77,7 @@ class Images {
     }
 
     return [
-        'image' => $src,
+      'image' => $src,
     ];
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -100,16 +100,6 @@ const allPlugins = [
     },
   ),
 
-  // Copy from one target to new destination.
-  new CopyWebpackPlugin([
-
-    // Find jQuery in node_modules and copy it to public folder
-    {
-      from: `${themeNodePath}/jquery/dist/jquery.min.js`,
-      to: themeOutput,
-    },
-  ]),
-
   // Create manifest.json file.
   new ManifestPlugin({seed: {}}),
 ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,7 +89,7 @@ const allPlugins = [
         {
           match: [
             '**/*.php',
-            `${themePublicPath}*.css`,
+            '**/*.css',
           ],
         },
       ],


### PR DESCRIPTION
Fixing issues on `development` https://github.com/infinum/wp-boilerplate/pull/133

- [X] Enqueue WordPress's jQuery
- [x] Register WordPress's jQuery as `$`
- [x] Fix BrowserSync's hot reloading (injecting css) - not working in both `master` and `development`(works when page reloading is enabled)

Changelog
---
* Updated composer, as a result phpcs rules and had to fix some issues
* jQuery is no longer on the package list, we load WordPress's jQuery as main `appllication.js` script dependancy (still available as `$` in `.js` files although not globally in window)
* Fixed a path issues that was preventing `.css` hot-reloading from working