### PR TITLE
Install script for 4.0.0

### DIFF
--- a/bin/theme-setup.js
+++ b/bin/theme-setup.js
@@ -143,9 +143,9 @@ const replaceThemeData = async(themeData) => {
   // BrowserSync proxy url.
   if (themeData.url) {
     await replace({
-      files: path.join(fullThemePath, 'webpack.config.js'),
-      from: /^const proxyUrl = .*$/m,
-      to: `const proxyUrl = '${themeData.url}';`,
+      files: path.join(fullThemePath, 'webpack', 'config.js'),
+      from: /proxyUrl: .*$/m,
+      to: `proxyUrl: '${themeData.url}',`,
     });
   }
 };

--- a/bin/theme-setup.js
+++ b/bin/theme-setup.js
@@ -215,14 +215,18 @@ const run = async() => {
   //  1. Preflight checklist
   // -----------------------------
 
-  const spinnerChecklist = ora('1. Pre-flight checklist').start();
-  await preFlightChecklist().then(() => {
-    spinnerChecklist.succeed();
-  }).catch((exception) => {
-    spinnerChecklist.fail();
-    error(exception);
-    process.exit();
-  });
+  if (scriptArgs.skipChecklist) {
+    ora('1. Skipping Pre-flight checklist').start().succeed();
+  } else {
+    const spinnerChecklist = ora('1. Pre-flight checklist').start();
+    await preFlightChecklist().then(() => {
+      spinnerChecklist.succeed();
+    }).catch((exception) => {
+      spinnerChecklist.fail();
+      error(exception);
+      process.exit();
+    });
+  }
 
   // -----------------------------
   //  2. Replace BrowserSync dev url

--- a/bin/theme-setup.js
+++ b/bin/theme-setup.js
@@ -152,6 +152,8 @@ const promptThemeData = ({ themeName, devUrl, noConfirm }) => {
   // -----------------------------
 
   do {
+    themeData.name = themeName;
+
     if (!themeName) {
       themeData.name = promptFor({
         label: `${emoji.get('green_book')} Please enter your theme name (shown in WordPress admin):`,
@@ -159,15 +161,13 @@ const promptThemeData = ({ themeName, devUrl, noConfirm }) => {
         error: 'Theme name field is required and cannot be empty.',
         minLength: 2,
       }).trim();
-    } else {
-      themeData.name = themeName;
     }
 
     // Build package name from theme name
     themeData.package = themeData.name.toLowerCase().split(' ').join('_');
 
-    // Build prefix from theme name using one of 2 methods.
-    // 1. If theme name has 2 or mor more words, use first letters of each word
+    // Build prefix from theme name using one of 2 methods...
+    // 1. If theme name has 2 or more words, use first letters of each word
     themeData.prefix = '';
     const themeNameWords = themeData.name.split(' ');
     if (themeNameWords && themeNameWords.length >= 2) {
@@ -188,14 +188,13 @@ const promptThemeData = ({ themeName, devUrl, noConfirm }) => {
     themeData.namespace = capCase(themeData.package);
   
     // Dev url
+    themeData.url = devUrl;
     if (!devUrl) {
       themeData.url = promptFor({
         label: `${emoji.get('earth_africa')} Please enter a theme development url (for local development with browsersync - no protocol):`,
         prompt: 'Dev url (e.g. dev.wordpress.com): ',
         error: 'Dev url is required and cannot be empty.',
       }).trim();
-    } else {
-      themeData.url = devUrl;
     }
 
     confirmed = summary([
@@ -225,34 +224,6 @@ const replaceThemeData = async (themeData, replaceAll = false) => {
         files: path.join(fullThemePath, 'style.css'),
         from: /^Theme Name: .*$/m,
         to: `Theme Name: ${themeData.name}`,
-      });
-    }
-  
-    // Description
-    if (themeData.description) {
-      await replace({
-        files: path.join(fullThemePath, 'functions.php'),
-        from: /^ \* Description:.*$/m,
-        to: ` * Description: ${themeData.description}`,
-      });
-      await replace({
-        files: path.join(fullThemePath, 'style.css'),
-        from: /^Description: .*$/m,
-        to: `Description: ${themeData.description}`,
-      });
-    }
-  
-    // Author
-    if (themeData.author) {
-      await replace({
-        files: path.join(fullThemePath, 'functions.php'),
-        from: /^ \* Author:.*$/m,
-        to: ` * Author: ${themeData.author}`,
-      });
-      await replace({
-        files: path.join(fullThemePath, 'style.css'),
-        from: /^Author: .*$/m,
-        to: `Author: ${themeData.author}`,
       });
     }
   

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start": "webpack --progress --watch --display-error-details --display-reasons --mode development",
     "build": "webpack --progress --mode production",
     "export": "node bin/export.js",
-    "setup": "node bin/theme-setup.js"
+    "setup": "npm install && node bin/theme-setup.js",
+    "setupAndReplace": "npm install && node bin/theme-setup.js --replaceThemeInfo"
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "npm run lintJs && npm run lintStyle && bash bin/lintPhp.sh",
     "start": "webpack --progress --watch --display-error-details --display-reasons --mode development",
     "build": "webpack --progress --mode production",
-    "export": "node bin/export.js"
+    "export": "node bin/export.js",
+    "setup": "node bin/theme-setup.js"
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "sass-loader": "^7.1.0",
     "style-loader": "^0.23.1",
     "stylelint": "^10.0.1",
-    "uglifyjs-webpack-plugin": "^2.1.2",
+    "terser-webpack-plugin": "^1.2.3",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.3.0",
     "webpack-manifest-plugin": "^2.0.4",

--- a/packages/create-wp-theme/theme-setup.js
+++ b/packages/create-wp-theme/theme-setup.js
@@ -320,9 +320,9 @@ const replaceThemeData = async(themeData) => {
   // BrowserSync proxy url.
   if (themeData.url) {
     await replace({
-      files: path.join(fullThemePath, 'webpack.config.js'),
-      from: /^const proxyUrl = .*$/m,
-      to: `const proxyUrl = '${themeData.url}';`,
+      files: path.join(fullThemePath, 'webpack', 'config.js'),
+      from: /proxyUrl: .*$/m,
+      to: `proxyUrl: '${themeData.url}',`,
     });
   }
 };

--- a/packages/create-wp-theme/theme-setup.js
+++ b/packages/create-wp-theme/theme-setup.js
@@ -400,14 +400,18 @@ const run = async() => {
   //  1. Preflight checklist
   // -----------------------------
 
-  const spinnerChecklist = ora('1. Pre-flight checklist').start();
-  await preFlightChecklist().then(() => {
-    spinnerChecklist.succeed();
-  }).catch((exception) => {
-    spinnerChecklist.fail();
-    error(exception);
-    process.exit();
-  });
+  if (scriptArgs.skipChecklist) {
+    ora('1. Skipping Pre-flight checklist').start().succeed();
+  } else {
+    const spinnerChecklist = ora('1. Pre-flight checklist').start();
+    await preFlightChecklist().then(() => {
+      spinnerChecklist.succeed();
+    }).catch((exception) => {
+      spinnerChecklist.fail();
+      error(exception);
+      process.exit();
+    });
+  }
 
   // -----------------------------
   //  2. Clone repo

--- a/src/general/class-manifest.php
+++ b/src/general/class-manifest.php
@@ -60,7 +60,7 @@ class Manifest extends LibManifest implements Service {
    *
    * @since 1.0.0
    */
-  public function get_manifest_assets_data( $key = null ) : string {
+  public static function get_manifest_assets_data( $key = null ) : string {
     if ( ! $key ) {
       return '';
     }

--- a/views/parts/google-rich-snippets.php
+++ b/views/parts/google-rich-snippets.php
@@ -22,12 +22,14 @@ $logo_img = Manifest::get_manifest_assets_data( 'images/logo.svg' );
       "@id": "https://google.com/article"
     },
     "headline": "<?php the_title(); ?>",
+  <?php if ( ! empty( $image ) ) { ?>
   "image": {
     "@type": "ImageObject",
     "url": "<?php echo esc_html( $image['image'] ); ?>",
     "height": <?php echo esc_html( $image['height'] ); ?>,
     "width": <?php echo esc_html( $image['width'] ); ?>
   },
+  <?php } ?>
   "datePublished": "<?php echo esc_html( get_the_time( 'c' ) ); ?>",
   "dateModified": "<?php echo esc_html( date( 'c', strtotime( $post->post_modified ) ) ); ?>",
   "author": {

--- a/webpack/production.js
+++ b/webpack/production.js
@@ -23,19 +23,10 @@ const plugins = [
 // All Optimizations used in production build.
 const optimization = {
   minimizer: [
-    new UglifyJsPlugin({
+    new TerserPlugin({
       cache: true,
       parallel: true,
       sourceMap: true,
-      uglifyOptions: {
-        output: {
-          comments: false,
-        },
-        compress: {
-          warnings: false,
-          drop_console: true, // eslint-disable-line camelcase
-        },
-      },
     }),
   ],
 };

--- a/webpack/production.js
+++ b/webpack/production.js
@@ -7,7 +7,7 @@ const project = require('./project');
 
 // Plugins.
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 
 // All Plugins used in production build.


### PR DESCRIPTION
A working install script for the new boilerplate setup using `eightshift-libs`.

Changelog
---
- Modified the local `theme-setup.js` so we can use that to fully setup the theme just like `npx create-wp-theme` (which won't work with the `development` branch - see below) - this is probably only temporary so we can test things before releasing `4.0.0`. To setup do the following.
  - Clone / download the theme to your `wp-content/themes` folder
  - `cd` there
  - run `npm install && node bin/theme-setup.js --replaceThemeInfo`
- Added optional `skipChecklist` argument - only really used for testing
- Replaced `uglify-webpack-plugin` with `terser-webpack-plugin` because the new version of uglify uses a library which can't minify ES6 modules (such as `@babel/pollyfill`)
- Changed the` proxyUrl` replacing part so it works with new setup
- Prettying code

The `npx create-wp-theme` won't work with both the current setup and `4.0.0` setup. Because of this I won't update the npm repository until we merge the `4.0.0` to production. In theory it should work with the current changes I made but there's no way to know until I update the repo.
