### PR TITLE
Setup from master by default

### DIFF
--- a/packages/create-wp-theme/package.json
+++ b/packages/create-wp-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-wp-theme",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": "Team Eightshift",
   "main": "",
   "license": "MIT",

--- a/packages/create-wp-theme/package.json
+++ b/packages/create-wp-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-wp-theme",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "Team Eightshift",
   "main": "",
   "license": "MIT",

--- a/packages/create-wp-theme/theme-setup.js
+++ b/packages/create-wp-theme/theme-setup.js
@@ -400,14 +400,18 @@ const run = async() => {
   //  1. Preflight checklist
   // -----------------------------
 
-  const spinnerChecklist = ora('1. Pre-flight checklist').start();
-  await preFlightChecklist().then(() => {
-    spinnerChecklist.succeed();
-  }).catch((exception) => {
-    spinnerChecklist.fail();
-    error(exception);
-    process.exit();
-  });
+  if (scriptArgs.skipChecklist) {
+    ora('1. Skipping Pre-flight checklist').start().succeed();
+  } else {
+    const spinnerChecklist = ora('1. Pre-flight checklist').start();
+    await preFlightChecklist().then(() => {
+      spinnerChecklist.succeed();
+    }).catch((exception) => {
+      spinnerChecklist.fail();
+      error(exception);
+      process.exit();
+    });
+  }
 
   // -----------------------------
   //  2. Clone repo
@@ -419,6 +423,8 @@ const run = async() => {
   // Pull from a different branch if specified in parameters
   if (scriptArgs.branch) {
     base += ` -b ${scriptArgs.branch}`;
+  } else {
+    base += ' -b master';
   }
 
   const gitClone = `${base} ${gitUrl} "${newThemeData.package}"`;

--- a/packages/create-wp-theme/theme-setup.js
+++ b/packages/create-wp-theme/theme-setup.js
@@ -320,9 +320,9 @@ const replaceThemeData = async(themeData) => {
   // BrowserSync proxy url.
   if (themeData.url) {
     await replace({
-      files: path.join(fullThemePath, 'webpack', 'config.js'),
-      from: /proxyUrl: .*$/m,
-      to: `proxyUrl: '${themeData.url}',`,
+      files: path.join(fullThemePath, 'webpack.config.js'),
+      from: /^const proxyUrl = .*$/m,
+      to: `const proxyUrl = '${themeData.url}';`,
     });
   }
 };
@@ -400,18 +400,14 @@ const run = async() => {
   //  1. Preflight checklist
   // -----------------------------
 
-  if (scriptArgs.skipChecklist) {
-    ora('1. Skipping Pre-flight checklist').start().succeed();
-  } else {
-    const spinnerChecklist = ora('1. Pre-flight checklist').start();
-    await preFlightChecklist().then(() => {
-      spinnerChecklist.succeed();
-    }).catch((exception) => {
-      spinnerChecklist.fail();
-      error(exception);
-      process.exit();
-    });
-  }
+  const spinnerChecklist = ora('1. Pre-flight checklist').start();
+  await preFlightChecklist().then(() => {
+    spinnerChecklist.succeed();
+  }).catch((exception) => {
+    spinnerChecklist.fail();
+    error(exception);
+    process.exit();
+  });
 
   // -----------------------------
   //  2. Clone repo
@@ -423,8 +419,6 @@ const run = async() => {
   // Pull from a different branch if specified in parameters
   if (scriptArgs.branch) {
     base += ` -b ${scriptArgs.branch}`;
-  } else {
-    base += ' -b master';
   }
 
   const gitClone = `${base} ${gitUrl} "${newThemeData.package}"`;

--- a/packages/create-wp-theme/theme-setup.js
+++ b/packages/create-wp-theme/theme-setup.js
@@ -423,6 +423,8 @@ const run = async() => {
   // Pull from a different branch if specified in parameters
   if (scriptArgs.branch) {
     base += ` -b ${scriptArgs.branch}`;
+  } else {
+    base += ' -b master';
   }
 
   const gitClone = `${base} ${gitUrl} "${newThemeData.package}"`;


### PR DESCRIPTION
As it was now, the `npx create-wp-theme` was cloning the default git branch (which is `development`)  and that wasn't compatible with our current changes in `development` related to `4.0.0`.

Now it installs from `master` by default but you can always specify which branch to install from using `npx create-wp-theme --branch someBranchName` optional argument.